### PR TITLE
Upgrade to Scala.js 1.0.0-M1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,6 @@ install:
   # We use coursier instead.
   - mkdir -p $HOME/.sbt/0.13/plugins/
   - echo 'addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC3")' > $HOME/.sbt/0.13/plugins/coursier.sbt
-  # While there is no published version of Scala.js 1.x, we have to locally build a snapshot.
-  - git clone https://github.com/scala-js/scala-js.git
-  - cd scala-js
-  - git checkout cc6610bf35332b5a52276b8fda69dee5ea72300f
-  - sbt ++$TRAVIS_SCALA_VERSION ir/publishLocal tools/publishLocal
-  - |
-      if [[ "${TEST_SBT_PLUGIN}" == "true" ]]; then
-        sbt ++$TRAVIS_SCALA_VERSION jsEnvs/publishLocal testAdapter/publishLocal sbtPlugin/publishLocal &&
-        sbt ++2.11.11 compiler/publishLocal library/publishLocal testInterface/publishLocal
-      fi
-  - cd ..
 script:
   - sbt ++$TRAVIS_SCALA_VERSION jsdependencies-core/test jsdependencies-core/doc
   - |

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val scalaJSVersion = "1.0.0-SNAPSHOT"
+val scalaJSVersion = "1.0.0-M1"
 
 inThisBuild(Seq(
   version := "0.1.0-SNAPSHOT",
@@ -74,6 +74,7 @@ lazy val `jsdependencies-core`: Project = project.in(file("jsdependencies-core")
 
     libraryDependencies ++= Seq(
       "org.scala-js" %% "scalajs-tools" % scalaJSVersion,
+      "com.googlecode.json-simple" % "json-simple" % "1.1.1" exclude("junit", "junit"),
 
       "com.novocode" % "junit-interface" % "0.11" % "test"
     )

--- a/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/JSDependency.scala
+++ b/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/JSDependency.scala
@@ -1,8 +1,8 @@
 package org.scalajs.jsdependencies.core
 
-import org.scalajs.core.tools.json._
-
 import org.scalajs.core.ir.Trees.isValidIdentifier
+
+import org.scalajs.jsdependencies.core.json._
 
 /** Expresses a dependency on a raw JS library and the JS libraries this library
  *  itself depends on.

--- a/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/JSDependencyManifest.scala
+++ b/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/JSDependencyManifest.scala
@@ -1,11 +1,12 @@
 package org.scalajs.jsdependencies.core
 
-import org.scalajs.core.tools.json._
-import org.scalajs.core.tools.io._
-
 import scala.collection.immutable.{Seq, Traversable}
 
 import java.io.{Reader, Writer}
+
+import org.scalajs.core.tools.io._
+
+import org.scalajs.jsdependencies.core.json._
 
 /** The information written to a "JS_DEPENDENCIES" manifest file. */
 final class JSDependencyManifest(

--- a/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/Origin.scala
+++ b/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/Origin.scala
@@ -1,6 +1,6 @@
 package org.scalajs.jsdependencies.core
 
-import org.scalajs.core.tools.json._
+import org.scalajs.jsdependencies.core.json._
 
 /** The place a JSDependency originated from */
 final class Origin(val moduleName: String, val configuration: String) {

--- a/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/json/Impl.scala
+++ b/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/json/Impl.scala
@@ -1,0 +1,38 @@
+package org.scalajs.jsdependencies.core.json
+
+import org.json.simple.JSONValue
+
+import scala.collection.JavaConverters._
+
+import java.io.{Writer, Reader}
+
+private[json] object Impl {
+
+  type Repr = Object
+
+  def fromString(x: String): Repr = x
+  def fromNumber(x: Number): Repr = x
+  def fromBoolean(x: Boolean): Repr = java.lang.Boolean.valueOf(x)
+  def fromList(x: List[Repr]): Repr = x.asJava
+  def fromMap(x: Map[String, Repr]): Repr = x.asJava
+
+  def toString(x: Repr): String = x.asInstanceOf[String]
+  def toNumber(x: Repr): Number = x.asInstanceOf[Number]
+  def toBoolean(x: Repr): Boolean =
+    x.asInstanceOf[java.lang.Boolean].booleanValue()
+  def toList(x: Repr): List[Repr] =
+    x.asInstanceOf[java.util.List[Repr]].asScala.toList
+  def toMap(x: Repr): Map[String, Repr] =
+    x.asInstanceOf[java.util.Map[String, Repr]].asScala.toMap
+
+  def serialize(x: Repr): String =
+    JSONValue.toJSONString(x)
+
+  def serialize(x: Repr, writer: Writer): Unit =
+    JSONValue.writeJSONString(x, writer)
+
+  def deserialize(str: String): Repr = JSONValue.parse(str)
+
+  def deserialize(reader: Reader): Repr = JSONValue.parse(reader)
+
+}

--- a/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/json/JSONDeserializer.scala
+++ b/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/json/JSONDeserializer.scala
@@ -1,0 +1,34 @@
+package org.scalajs.jsdependencies.core.json
+
+private[core] trait JSONDeserializer[T] {
+  def deserialize(x: JSON): T
+}
+
+private[core] object JSONDeserializer {
+
+  implicit object stringJSON extends JSONDeserializer[String] {
+    def deserialize(x: JSON): String = Impl.toString(x)
+  }
+
+  implicit object intJSON extends JSONDeserializer[Int] {
+    def deserialize(x: JSON): Int = Impl.toNumber(x).intValue()
+  }
+
+  implicit object booleanJSON extends JSONDeserializer[Boolean] {
+    def deserialize(x: JSON): Boolean = Impl.toBoolean(x)
+  }
+
+  implicit def listJSON[T: JSONDeserializer]: JSONDeserializer[List[T]] = {
+    new JSONDeserializer[List[T]] {
+      def deserialize(x: JSON): List[T] = Impl.toList(x).map(fromJSON[T] _)
+    }
+  }
+
+  implicit def mapJSON[V: JSONDeserializer]: JSONDeserializer[Map[String, V]] = {
+    new JSONDeserializer[Map[String, V]] {
+      def deserialize(x: JSON): Map[String, V] =
+        Impl.toMap(x).mapValues(fromJSON[V] _)
+    }
+  }
+
+}

--- a/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/json/JSONObjBuilder.scala
+++ b/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/json/JSONObjBuilder.scala
@@ -1,0 +1,20 @@
+package org.scalajs.jsdependencies.core.json
+
+import scala.collection.mutable
+
+private[core] class JSONObjBuilder {
+
+  private val flds = mutable.Map.empty[String, JSON]
+
+  def fld[T: JSONSerializer](name: String, v: T): this.type = {
+    flds.put(name, v.toJSON)
+    this
+  }
+
+  def opt[T: JSONSerializer](name: String, v: Option[T]): this.type = {
+    v.foreach(v => flds.put(name, v.toJSON))
+    this
+  }
+
+  def toJSON: JSON = Impl.fromMap(flds.toMap)
+}

--- a/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/json/JSONObjExtractor.scala
+++ b/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/json/JSONObjExtractor.scala
@@ -1,0 +1,13 @@
+package org.scalajs.jsdependencies.core.json
+
+import scala.collection.mutable
+
+private[core] class JSONObjExtractor(rawData: JSON) {
+  private val data = Impl.toMap(rawData)
+
+  def fld[T: JSONDeserializer](name: String): T =
+    fromJSON[T](data(name))
+
+  def opt[T: JSONDeserializer](name: String): Option[T] =
+    data.get(name).map(fromJSON[T] _)
+}

--- a/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/json/JSONSerializer.scala
+++ b/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/json/JSONSerializer.scala
@@ -1,0 +1,34 @@
+package org.scalajs.jsdependencies.core.json
+
+private[core] trait JSONSerializer[T] {
+  def serialize(x: T): JSON
+}
+
+private[core] object JSONSerializer {
+
+  implicit object stringJSON extends JSONSerializer[String] {
+    def serialize(x: String): JSON = Impl.fromString(x)
+  }
+
+  implicit object intJSON extends JSONSerializer[Int] {
+    def serialize(x: Int): JSON = Impl.fromNumber(x)
+  }
+
+  implicit object booleanJSON extends JSONSerializer[Boolean] {
+    def serialize(x: Boolean): JSON = Impl.fromBoolean(x)
+  }
+
+  implicit def listJSON[T: JSONSerializer]: JSONSerializer[List[T]] = {
+    new JSONSerializer[List[T]] {
+      def serialize(x: List[T]): JSON = Impl.fromList(x.map(_.toJSON))
+    }
+  }
+
+  implicit def mapJSON[V: JSONSerializer]:JSONSerializer[Map[String, V]] = {
+    new JSONSerializer[Map[String, V]] {
+      def serialize(x: Map[String, V]): JSON =
+        Impl.fromMap(x.mapValues(_.toJSON))
+    }
+  }
+
+}

--- a/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/json/package.scala
+++ b/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/json/package.scala
@@ -1,0 +1,33 @@
+package org.scalajs.jsdependencies.core
+
+import java.io.{Reader, Writer}
+
+/** Some type-class lightweight wrappers around simple-json.
+ *
+ *  They allow to write `xyz.toJSON` to obtain classes that can be
+ *  serialized by simple-json and `fromJSON[T](xyz)` to get an
+ *  object back.
+ */
+package object json {
+  private[core] type JSON = Impl.Repr
+
+  private[core] implicit class JSONPimp[T: JSONSerializer](x: T) {
+    def toJSON: JSON = implicitly[JSONSerializer[T]].serialize(x)
+  }
+
+  private[core] def fromJSON[T](x: JSON)(implicit d: JSONDeserializer[T]): T =
+    d.deserialize(x)
+
+  private[core] def writeJSON(x: JSON, writer: Writer): Unit =
+    Impl.serialize(x, writer)
+
+  private[core] def jsonToString(x: JSON): String =
+    Impl.serialize(x)
+
+  private[core] def readJSON(str: String): JSON =
+    Impl.deserialize(str)
+
+  private[core] def readJSON(reader: Reader): JSON =
+    Impl.deserialize(reader)
+
+}

--- a/jsdependencies-sbt-plugin/src/main/scala/org/scalajs/jsdependencies/sbtplugin/JSDependenciesPlugin.scala
+++ b/jsdependencies-sbt-plugin/src/main/scala/org/scalajs/jsdependencies/sbtplugin/JSDependenciesPlugin.scala
@@ -11,7 +11,6 @@ import sbt.Keys._
 import org.scalajs.core.ir.Utils.escapeJS
 
 import org.scalajs.core.tools.io.{IO => toolsIO, _}
-import org.scalajs.core.tools.json._
 
 import org.scalajs.jsenv.VirtualFileMaterializer
 
@@ -144,8 +143,7 @@ object JSDependenciesPlugin extends AutoPlugin {
       container: VirtualFileContainer): List[JSDependencyManifest] = {
     container.listEntries(_ == JSDependencyManifest.ManifestFileName) {
       (_, stream) =>
-        val json = readJSON(new InputStreamReader(stream, "UTF-8"))
-        fromJSON[JSDependencyManifest](json)
+        JSDependencyManifest.read(new InputStreamReader(stream, "UTF-8"))
     }
   }
 
@@ -264,7 +262,7 @@ object JSDependenciesPlugin extends AutoPlugin {
             new ExactFilter(JSDependencyManifest.ManifestFileName),
             collectJar = jsDependencyManifestsInJar(_),
             collectFile = { (file, _) =>
-              fromJSON[JSDependencyManifest](readJSON(IO.read(file)))
+              JSDependencyManifest.read(FileVirtualTextFile(file))
             })
 
         rawManifests.map(manifests => filter(manifests.toTraversable))


### PR DESCRIPTION
This includes sourcing in the `json` private package of `test-adapter`. It used to be a public component of `scalajs-tools`, but that is not the case anymore.