### PR TITLE
Remove `jsDependencies += RuntimeDOM` and `requiresDOM := true`.

### DIFF
--- a/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/JSDependencyManifest.scala
+++ b/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/JSDependencyManifest.scala
@@ -11,16 +11,14 @@ import org.scalajs.jsdependencies.core.json._
 /** The information written to a "JS_DEPENDENCIES" manifest file. */
 final class JSDependencyManifest(
     val origin: Origin,
-    val libDeps: List[JSDependency],
-    val requiresDOM: Boolean) {
+    val libDeps: List[JSDependency]) {
 
   import JSDependencyManifest._
 
   override def equals(that: Any): Boolean = that match {
     case that: JSDependencyManifest =>
       this.origin == that.origin &&
-      this.libDeps == that.libDeps &&
-      this.requiresDOM == that.requiresDOM
+      this.libDeps == that.libDeps
     case _ =>
       false
   }
@@ -29,9 +27,8 @@ final class JSDependencyManifest(
     import scala.util.hashing.MurmurHash3._
     var acc = HashSeed
     acc = mix(acc, origin.##)
-    acc = mix(acc, libDeps.##)
-    acc = mixLast(acc, requiresDOM.##)
-    finalizeHash(acc, 3)
+    acc = mixLast(acc, libDeps.##)
+    finalizeHash(acc, 2)
   }
 
   override def toString(): String = {
@@ -39,8 +36,6 @@ final class JSDependencyManifest(
     b ++= s"JSDependencyManifest(origin=$origin"
     if (libDeps.nonEmpty)
       b ++= s", libDeps=$libDeps"
-    if (requiresDOM)
-      b ++= s", requiresDOM=$requiresDOM"
     b ++= ")"
     b.result()
   }
@@ -61,7 +56,6 @@ object JSDependencyManifest {
       new JSONObjBuilder()
         .fld("origin", x.origin)
         .opt("libDeps", optList(x.libDeps))
-        .opt("requiresDOM", if (x.requiresDOM) Some(true) else None)
         .toJSON
     }
   }
@@ -71,8 +65,7 @@ object JSDependencyManifest {
       val obj = new JSONObjExtractor(x)
       new JSDependencyManifest(
           obj.fld[Origin]("origin"),
-          obj.opt[List[JSDependency]]("libDeps").getOrElse(Nil),
-          obj.opt[Boolean]("requiresDOM").getOrElse(false))
+          obj.opt[List[JSDependency]]("libDeps").getOrElse(Nil))
     }
   }
 

--- a/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/ManifestFilters.scala
+++ b/jsdependencies-core/src/main/scala/org/scalajs/jsdependencies/core/ManifestFilters.scala
@@ -41,8 +41,7 @@ object ManifestFilters {
             jsDependency.dependencies.map(mapping),
             jsDependency.commonJSName,
             jsDependency.minifiedResourceName.map(mapping))
-      new JSDependencyManifest(manifest.origin, filteredJSDeps,
-          manifest.requiresDOM)
+      new JSDependencyManifest(manifest.origin, filteredJSDeps)
     }
   }
 }

--- a/jsdependencies-core/src/test/scala/org/scalajs/jsdependencies/core/ManifestFiltersTest.scala
+++ b/jsdependencies-core/src/test/scala/org/scalajs/jsdependencies/core/ManifestFiltersTest.scala
@@ -8,7 +8,7 @@ class ManifestFiltersTest {
 
   private def mkManifest(module: String, deps: String*) = {
     new JSDependencyManifest(new Origin(module, "compile"),
-        deps.map(new JSDependency(_)).toList, requiresDOM = false)
+        deps.map(new JSDependency(_)).toList)
   }
 
   @Test

--- a/jsdependencies-sbt-plugin/src/main/scala/org/scalajs/jsdependencies/sbtplugin/AbstractJSDeps.scala
+++ b/jsdependencies-sbt-plugin/src/main/scala/org/scalajs/jsdependencies/sbtplugin/AbstractJSDeps.scala
@@ -73,10 +73,3 @@ object ProvidedJSModuleID {
   def apply(name: String, configurations: Option[String]): ProvidedJSModuleID =
     ProvidedJSModuleID(new JSDependency(name, Nil), configurations)
 }
-
-final case class RuntimeDOMDep(
-    configurations: Option[String]) extends AbstractJSDep {
-
-  protected def withConfigs(configs: Option[String]): RuntimeDOMDep =
-    copy(configurations = configs)
-}

--- a/sbt-plugin-test/build.sbt
+++ b/sbt-plugin-test/build.sbt
@@ -70,7 +70,7 @@ lazy val jsDependenciesTest = withRegretionTestForIssue2243(
     }
   ).
   settings(inConfig(Compile)(Seq(
-    packageJSDependencies <<= packageJSDependencies.dependsOn(Def.task {
+    packageJSDependencies := packageJSDependencies.dependsOn(Def.task {
       // perform verifications on the ordering and deduplications
       val resolvedDeps = resolvedJSDependencies.value.data
       val relPaths = resolvedDeps.map(_.info.relPath)
@@ -106,7 +106,7 @@ lazy val jsDependenciesTest = withRegretionTestForIssue2243(
           "compressed/history.js appears before foo.js")
 
       streams.value.log.info("jsDependencies resolution test passed")
-    })
+    }).value
   )): _*).
   dependsOn(jsDependenciesTestDependee) // depends on jQuery
 )

--- a/sbt-plugin-test/build.sbt
+++ b/sbt-plugin-test/build.sbt
@@ -34,7 +34,6 @@ lazy val jsDependenciesTestDependee = project.
   settings(
     // This project contains some jsDependencies to test in jsDependenciesTest
     jsDependencies ++= Seq(
-        RuntimeDOM,
         // The jsDependenciesTest relies on this jQuery dependency
         // If you change it, make sure we still test properly
         "org.webjars" % "jquery" % "1.10.2" / "jquery.js"


### PR DESCRIPTION
Since they are deprecated in Scala.js 0.6.20, we can now remove them from jsdependencies 1.x.