### PR TITLE
Fix #40: Generate valid path names for `require-$name.js` files.

### DIFF
--- a/sbt-plugin-test/build.sbt
+++ b/sbt-plugin-test/build.sbt
@@ -11,7 +11,8 @@ addCommandAlias("testAll",
     ";jsDependenciesTest/packageJSDependencies" +
     ";jsDependenciesTest/packageMinifiedJSDependencies" +
     ";jsDependenciesTest/regressionTestForIssue2243" +
-    ";jsNoDependenciesTest/regressionTestForIssue2243")
+    ";jsNoDependenciesTest/regressionTestForIssue2243" +
+    ";jsDependenciesRunTest/run")
 
 val regressionTestForIssue2243 = TaskKey[Unit]("regressionTestForIssue2243",
   "", KeyRanks.BTask)
@@ -114,3 +115,14 @@ lazy val jsNoDependenciesTest = withRegretionTestForIssue2243(
   project.
   enablePlugins(ScalaJSPlugin, JSDependenciesPlugin)
 )
+
+lazy val jsDependenciesRunTest =
+  project.
+  enablePlugins(ScalaJSPlugin, JSDependenciesPlugin).
+  settings(
+    scalaJSUseMainModuleInitializer := true,
+    jsDependencies ++= Seq(
+        // #40 Make sure we can run in the presence of a commonJSName
+        "org.webjars" % "mustachejs" % "0.8.2" / "mustache.js" commonJSName "Mustache",
+    ),
+  )

--- a/sbt-plugin-test/jsDependenciesRunTest/src/main/scala/test/Test.scala
+++ b/sbt-plugin-test/jsDependenciesRunTest/src/main/scala/test/Test.scala
@@ -1,0 +1,11 @@
+package test
+
+import scala.scalajs.js
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    println("Hello world")
+    assert(js.typeOf(js.Dynamic.global.Mustache) == "object")
+    assert((js.Dynamic.global.Mustache.version: Any) == "0.8.1")
+  }
+}


### PR DESCRIPTION
We used to embed the target URI in the file name, which generates invalid paths. This used to be fine when we used our own virtual files, whose in-memory files accepted any string as path. Since we are now using Jimfs, we need to use correct path names.

We now generate file names based on the `commonJSName`. Since `commonJSName` must be a valid JavaScript identifier, it is also a valid file name (in particular, it cannot contain the characters `: ; / \`). In the unlikely event that two libraries have the same `commonJSName` (which would probably be erroneous anyway, but still), we use suffixes to generated distinct file names.

In addition, we use the `File.getAbsolutePath` in the call to `require()`, instead of a URI, because `require` doesn't support `file:` URIs; it wants a regular absolute file path instead.

---

/cc @japgolly